### PR TITLE
updating copyright url

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
     <!--   Please don't remove this!   -->
     <footer id='bottom-footer'>
         <div class='center-footer' style='font-size: .8rem;'>
-            ©️ Template made by <a class='saho' href='https://xyna.space/@luna?template'>Luna</a>
+            ©️ Template made by <a class='saho' href='https://lunish.nl/luna'>Luna</a>
             <!-- GPL-3.0 License > https://github.com/Luna-devv/Modern-Website/blob/main/LICENSE -->
         </div>
     </footer>


### PR DESCRIPTION
Updated `https://xyna.space/@luna?template` to `https://lunish.nl/luna` in the copyright footer due to domain expiration.